### PR TITLE
Update activity_occurrence.sql

### DIFF
--- a/macros/activity_occurrence.sql
+++ b/macros/activity_occurrence.sql
@@ -4,6 +4,7 @@ row_number() over (
     partition by
         coalesce(
             {{ safe_cast("customer", type_string()) }},
+            {{ safe_cast("activity", type_string()) }},
             {{ safe_cast("anonymous_customer_id", type_string()) }}
         )
     order by ts asc, activity_id asc
@@ -12,6 +13,7 @@ lead(ts) over (
     partition by
         coalesce(
             {{ safe_cast("customer", type_string()) }},
+            {{ safe_cast("activity", type_string()) }},
             {{ safe_cast("anonymous_customer_id", type_string()) }}
         )
     order by ts asc, activity_id asc


### PR DESCRIPTION
Problem: a general transaction table with shared features would require tons of repeated code to define in this spec.

Solution: add activity to the partition so that a seed can be used to run a case/when that maps the different transactions